### PR TITLE
Fix thin clones

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-COMMANDS=Plugin.Query Plugin.diagnostics SR.create SR.ls SR.destroy SR.attach SR.stat SR.detach Volume.create Volume.destroy Volume.stat Volume.snapshot Volume.clone Volume.set_name Volume.set_description
+COMMANDS=Plugin.Query Plugin.diagnostics SR.create SR.set_name SR.set_description SR.ls SR.destroy SR.attach SR.stat SR.detach Volume.create Volume.destroy Volume.stat Volume.snapshot Volume.clone Volume.set_name Volume.set_description
 LIBRARIES=lvm.ml common.ml
 
 .PHONY: clean

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-COMMANDS=Plugin.Query Plugin.diagnostics SR.create SR.ls SR.destroy SR.attach SR.stat SR.detach Volume.create Volume.destroy Volume.stat Volume.snapshot Volume.clone
+COMMANDS=Plugin.Query Plugin.diagnostics SR.create SR.ls SR.destroy SR.attach SR.stat SR.detach Volume.create Volume.destroy Volume.stat Volume.snapshot Volume.clone Volume.set_name Volume.set_description
 LIBRARIES=lvm.ml common.ml
 
 .PHONY: clean

--- a/src/SR.set_description
+++ b/src/SR.set_description
@@ -1,0 +1,36 @@
+#!/usr/bin/env ocamlscript
+Ocaml.sources := ["common.ml"; "lvm.ml"];
+Ocaml.packs := ["xapi-storage"; "cmdliner"; "re.str"; "oUnit"; "uri"];
+Ocaml.ocamlflags := ["-thread"]
+--
+(*
+ * Copyright (C) Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+open Common
+
+module Command = struct
+  open Storage.Volume.Types
+  include SR.Set_description
+
+  let command common { SR.Set_description.In.dbg; sr; new_description } =
+    ()
+end
+
+module Test = struct
+  open OUnit
+
+  let test common = ()
+end
+
+module M = Make(Command)(Test)
+let _ = M.main ()

--- a/src/SR.set_name
+++ b/src/SR.set_name
@@ -1,0 +1,36 @@
+#!/usr/bin/env ocamlscript
+Ocaml.sources := ["common.ml"; "lvm.ml"];
+Ocaml.packs := ["xapi-storage"; "cmdliner"; "re.str"; "oUnit"; "uri"];
+Ocaml.ocamlflags := ["-thread"]
+--
+(*
+ * Copyright (C) Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+open Common
+
+module Command = struct
+  open Storage.Volume.Types
+  include SR.Set_name
+
+  let command common { SR.Set_name.In.dbg; sr; new_name } =
+    ()
+end
+
+module Test = struct
+  open OUnit
+
+  let test common = ()
+end
+
+module M = Make(Command)(Test)
+let _ = M.main ()

--- a/src/Volume.set_description
+++ b/src/Volume.set_description
@@ -1,0 +1,36 @@
+#!/usr/bin/env ocamlscript
+Ocaml.sources := ["common.ml"; "lvm.ml"];
+Ocaml.packs := ["xapi-storage"; "cmdliner"; "re.str"; "oUnit"; "uri"];
+Ocaml.ocamlflags := ["-thread"]
+--
+(*
+ * Copyright (C) Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+open Common
+
+module Command = struct
+  open Storage.Volume.Types
+  include Volume.Set_description
+
+  let command common { Volume.Set_description.In.dbg; sr; key; new_description } =
+    ()
+end
+
+module Test = struct
+  open OUnit
+
+  let test common = ()
+end
+
+module M = Make(Command)(Test)
+let _ = M.main ()

--- a/src/Volume.set_name
+++ b/src/Volume.set_name
@@ -1,0 +1,36 @@
+#!/usr/bin/env ocamlscript
+Ocaml.sources := ["common.ml"; "lvm.ml"];
+Ocaml.packs := ["xapi-storage"; "cmdliner"; "re.str"; "oUnit"; "uri"];
+Ocaml.ocamlflags := ["-thread"]
+--
+(*
+ * Copyright (C) Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+open Common
+
+module Command = struct
+  open Storage.Volume.Types
+  include Volume.Set_name
+
+  let command common { Volume.Set_name.In.dbg; sr; key; new_name } =
+    ()
+end
+
+module Test = struct
+  open OUnit
+
+  let test common = ()
+end
+
+module M = Make(Command)(Test)
+let _ = M.main ()

--- a/src/lvm.ml
+++ b/src/lvm.ml
@@ -179,7 +179,7 @@ let lvcreate vg_name lv_name kind =
     let size_mb = Int64.to_string (Int64.div (Int64.add 1048575L bytes) (1048576L)) in
     [ "-V"; size_mb ^ "m"; "-T"; vg_name ^ "/" ^ thin_pool_name; "-n" ]
   | `Snapshot name ->
-    [ "-s"; vg_name ^ "/" ^ lv_name; "-n" ] in
+    [ "-k"; "n"; "-s"; vg_name ^ "/" ^ lv_name; "-n" ] in
   let lv_name = mangle_lv_name lv_name in
   let lv_name' = String.length lv_name in
   let rec retry attempts_remaining suffix =


### PR DESCRIPTION
By default LVM snapshots are created with "skip activation" set, which doesn't make any sense for our use-case.

The SMAPIv3 interface requires the implementation of `Volume.set_name` and `Volume.set_description`